### PR TITLE
Fix client not disconnecting

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -91,6 +91,7 @@ class NtripClient extends EventEmitter {
    */
   close() {
     this.isClose = true;
+    this.client.end();
     this.emit('close');
   }
 
@@ -119,14 +120,17 @@ class NtripClient extends EventEmitter {
     if (this.interval <= 0) {
       return;
     }
-
-    while (true) {
+    let keepLooping = true;
+    while (keepLooping) {
       if (utils.checkXyz(this.xyz) && this.isReady) {
         const gga = utils.encodeGGA(this.xyz) + '\r\n';
         this.write(gga);
       }
 
       await utils.sleep(this.interval);
+      if (this.isClose) {
+        keepLooping = false;
+      }
     }
   }
 


### PR DESCRIPTION
Ntrip-client doesn't disconnect even after calling close() function. So, to forcibly close the connection I have modified the close() function and loop() function.